### PR TITLE
Add parseErikd which does direct array accesses

### DIFF
--- a/bench/Speed.hs
+++ b/bench/Speed.hs
@@ -25,6 +25,7 @@ main =
              "4KB"
              [ bench "hexml" (whnf Hexml.parse input)
              , bench "xeno" (whnf Xeno.parse input)
+             , bench "xeno-erikd" (whnf Xeno.parseErikd input)
              , bench "xml" (nf XML.parseXMLDoc input)
              ])
     , env
@@ -34,6 +35,7 @@ main =
              "42KB"
              [ bench "hexml" (whnf Hexml.parse input)
              , bench "xeno" (whnf Xeno.parse input)
+             , bench "xeno-erikd" (whnf Xeno.parseErikd input)
              , bench "xml" (nf XML.parseXMLDoc input)
              ])
     , env
@@ -43,6 +45,7 @@ main =
              "52KB"
              [ bench "hexml" (whnf Hexml.parse input)
              , bench "xeno" (whnf Xeno.parse input)
+             , bench "xeno-erikd" (whnf Xeno.parseErikd input)
              , bench "xml" (nf XML.parseXMLDoc input)
              ])
     , env
@@ -52,6 +55,7 @@ main =
              "182KB"
              [ bench "hexml" (whnf Hexml.parse input)
              , bench "xeno" (whnf Xeno.parse input)
+             , bench "xeno-erikd" (whnf Xeno.parseErikd input)
              , bench "xml" (nf XML.parseXMLDoc input)
              ])
     ]


### PR DESCRIPTION
Not sure of the value of either `parse` or `parseErikd` as they don't
actually *do* anything. However running the benchmarks on my laptop
suggests `parseErikd` (which I *think* is correct) is about 2x faster
than the original.